### PR TITLE
Fix to work in ruby 3.2

### DIFF
--- a/lib/splendor_game/version.rb
+++ b/lib/splendor_game/version.rb
@@ -1,3 +1,3 @@
 module SplendorGame
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/splendor_game.gemspec
+++ b/splendor_game.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   
-  spec.add_dependency "highline", "~> 1.7"
+  spec.add_dependency "highline", "~> 2.1"
 end


### PR DESCRIPTION
At some point in the last 6 years, highline v1 stopped working with the latest ruby versions, upgrading to v2 seems to have fixed it.